### PR TITLE
Fixing typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ collectionItems = elemeno.getCollectionItems('recipes', options)
 puts collectionItems
 ```
 
-#### `elemeno.getCollectionItems(collectionSlug, itemSlug, [options])`
+#### `elemeno.getCollectionItem(collectionSlug, itemSlug, [options])`
 
 ```ruby
 collectionItem = elemeno.getCollectionItem('recipes', 'apple-pie')


### PR DESCRIPTION
There was an extra `s` in the example.